### PR TITLE
[Feature] Add items number limit before delay to avoid robot check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ typings/
 # Custom Misc
 build/
 builds/
+.DS_Store

--- a/src/gscc.js
+++ b/src/gscc.js
@@ -623,7 +623,7 @@ $__gscc.app = {
     );
 
     let titleSearchString;
-    let rawTitle = item.getField('title').replace(/<sub>/g, '').replace(/<\/sub>/g, ''); // 去掉 <sub> 和 </sub>
+    let rawTitle = item.getField('title').replace(/<sub>/g, '').replace(/<\/sub>/g, ''); 
 
     if (useSearchTitleFuzzyMatch) {
       $__gscc.debugger.info(

--- a/src/gscc.js
+++ b/src/gscc.js
@@ -623,15 +623,17 @@ $__gscc.app = {
     );
 
     let titleSearchString;
+    let rawTitle = item.getField('title').replace(/<sub>/g, '').replace(/<\/sub>/g, ''); // 去掉 <sub> 和 </sub>
+
     if (useSearchTitleFuzzyMatch) {
       $__gscc.debugger.info(
         `Search Param: Using Fuzzy Title Match per Preferences`,
       );
-      titleSearchString = `${item.getField('title')}`;
+      titleSearchString = `${rawTitle}`;
     } else {
       // this is a dead match; kinda risky for hand-entered data but match is
       // good on Zotero grabs
-      titleSearchString = `"${item.getField('title')}"`;
+      titleSearchString = `"${rawTitle}"`;
     }
 
     let paramAuthors = '';

--- a/src/locale/en-US/gscc-prefs.ftl
+++ b/src/locale/en-US/gscc-prefs.ftl
@@ -2,6 +2,7 @@ preferences-gscc-enable-random-wait-timing = Set Google Scholar Request Random W
 preferences-gscc-random-wait-timing-explain = To attempt to not trigger the IP shadow ban that Google Scholar implements, GSCC uses a random interval per HTTP request. You can change the window by revising the milliseconds below.
 preferences-gscc-randomWaitMinMs = Minimum Request Wait (milliseconds)
 preferences-gscc-randomWaitMaxMs = Maximum Request Wait (milliseconds)
+preferences-gscc-processedCountLimit = Number of intermittent items
 preferences-gscc-search-params = Custom Search Parameters
 preferences-gscc-search-params-explain = Depending on the types of papers you import, sometimes finding matches can be hard. The latest v4.1 of GSCC allows changing the search behavior through flags to help when you need it. In most cases, you shouldn't need the flags below, but if you're having issues, different combinations in different global regions can sometimes help.
 preferences-gscc-useSearchTitleFuzzyMatch= Use Fuzzy Title Match

--- a/src/locale/es-ES/gscc-prefs.ftl
+++ b/src/locale/es-ES/gscc-prefs.ftl
@@ -2,6 +2,7 @@ preferences-gscc-enable-random-wait-timing = Establecer intervalos de espera ale
 preferences-gscc-random-wait-timing-explain = Para intentar no activar la prohibición de IP que implementa Google Scholar, GSCC utiliza un intervalo aleatorio por cada solicitud HTTP. Puede cambiar la ventana modificando los milisegundos a continuación.
 preferences-gscc-randomWaitMinMs = Espera mínima de solicitud (milisegundos)
 preferences-gscc-randomWaitMaxMs = Espera máxima de solicitud (milisegundos)
+preferences-gscc-processedCountLimit = Número de artículos intermitentes
 preferences-gscc-search-params = Parámetros de búsqueda personalizados
 preferences-gscc-search-params-explain = Dependiendo de los tipos de documentos que importe, a veces puede ser difícil encontrar coincidencias. La última versión v4.1 de GSCC permite cambiar el comportamiento de búsqueda mediante opciones para ayudarle cuando lo necesite. En la mayoría de los casos, no necesitará las opciones a continuación, pero si tiene problemas, diferentes combinaciones en distintas regiones globales pueden ayudar.
 preferences-gscc-useSearchTitleFuzzyMatch = Usar coincidencia de título difusa

--- a/src/locale/fr-FR/gscc-prefs.ftl
+++ b/src/locale/fr-FR/gscc-prefs.ftl
@@ -2,6 +2,7 @@ preferences-gscc-enable-random-wait-timing = Définir des intervalles d'attente 
 preferences-gscc-random-wait-timing-explain = Pour tenter de ne pas déclencher l'interdiction IP imposée par Google Scholar, GSCC utilise un intervalle aléatoire pour chaque requête HTTP. Vous pouvez modifier la fenêtre en révisant les millisecondes ci-dessous.
 preferences-gscc-randomWaitMinMs = Temps d'attente minimum (millisecondes)
 preferences-gscc-randomWaitMaxMs = Temps d'attente maximum (millisecondes)
+preferences-gscc-processedCountLimit = Nombre d'éléments intermittents
 preferences-gscc-search-params = Paramètres de recherche personnalisés
 preferences-gscc-search-params-explain = En fonction des types de documents que vous importez, il peut parfois être difficile de trouver des correspondances. La dernière version v4.1 de GSCC permet de modifier le comportement de recherche via des options pour vous aider en cas de besoin. Dans la plupart des cas, vous n'aurez pas besoin de ces options, mais si vous rencontrez des problèmes, différentes combinaisons dans différentes régions peuvent parfois aider.
 preferences-gscc-useSearchTitleFuzzyMatch = Utiliser la correspondance floue des titres

--- a/src/locale/ja-JP/gscc-prefs.ftl
+++ b/src/locale/ja-JP/gscc-prefs.ftl
@@ -2,6 +2,7 @@ preferences-gscc-enable-random-wait-timing = Google Scholar リクエストの�
 preferences-gscc-random-wait-timing-explain = Google Scholar が実施する IP ブロックを回避するため、GSCC は各 HTTP リクエストにランダムな間隔を使用します。以下のミリ秒単位の設定を変更してウィンドウを調整できます。
 preferences-gscc-randomWaitMinMs = 最小リクエスト待機時間（ミリ秒）
 preferences-gscc-randomWaitMaxMs = 最大リクエスト待機時間（ミリ秒）
+preferences-gscc-processedCountLimit = 断続的なアイテムの数
 preferences-gscc-search-params = カスタム検索パラメータ
 preferences-gscc-search-params-explain = インポートする論文の種類によっては、マッチを見つけるのが難しい場合があります。最新の GSCC v4.1 では、必要に応じてフラグを使用して検索動作を変更することができます。ほとんどの場合、以下のフラグは必要ありませんが、問題が発生した場合、異なる地域で異なる組み合わせが役立つことがあります。
 preferences-gscc-useSearchTitleFuzzyMatch = タイトルのファジーマッチを使用

--- a/src/locale/zh-CH/gscc-prefs.ftl
+++ b/src/locale/zh-CH/gscc-prefs.ftl
@@ -2,6 +2,7 @@ preferences-gscc-enable-random-wait-timing = 设置 Google 学术请求随机等
 preferences-gscc-random-wait-timing-explain = 为了尝试避免触发 Google 学术实施的 IP 阴影禁令，GSCC 对每个 HTTP 请求使用随机间隔。您可以通过修改下面的毫秒数来更改窗口。
 preferences-gscc-randomWaitMinMs = 最小请求等待时间（毫秒）
 preferences-gscc-randomWaitMaxMs = 最大请求等待时间（毫秒）
+preferences-gscc-processedCountLimit = 间歇条目个数
 preferences-gscc-search-params = 自定义搜索参数
 preferences-gscc-search-params-explain = 根据您导入的论文类型，有时找到匹配项会很困难。最新的 GSCC v4.1 允许通过标志改变搜索行为，以便在需要时提供帮助。在大多数情况下，您不需要使用以下标志，但如果遇到问题，不同全球区域的不同组合有时会有所帮助。
 preferences-gscc-useSearchTitleFuzzyMatch = 使用模糊标题匹配

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1,6 +1,7 @@
 pref('extensions.zotero.gscc.useRandomWait', true);
 pref('extensions.zotero.gscc.randomWaitMinMs', 1000);
 pref('extensions.zotero.gscc.randomWaitMaxMs', 5000);
+pref('extensions.zotero.gscc.processedCountLimit', 15);
 pref('extensions.zotero.gscc.useSearchTitleFuzzyMatch', false);
 pref('extensions.zotero.gscc.useSearchAuthorsMatch', true);
 pref('extensions.zotero.gscc.useDateRangeMatch', false);

--- a/src/prefs.xhtml
+++ b/src/prefs.xhtml
@@ -35,6 +35,17 @@
       type="text"
       preference="extensions.zotero.gscc.randomWaitMaxMs"
     />
+    <!-- Add new input for processedCount limit -->
+    <label>
+      <html:h3
+        id="preferences-gscc-processedCountLimit"
+        data-l10n-id="preferences-gscc-processedCountLimit"
+      />
+    </label>
+    <html:input
+      type="text"
+      preference="extensions.zotero.gscc.processedCountLimit"
+    />
   </groupbox>
   <groupbox aria-labelledby="preferences-gscc-search-params">
     <vbox>

--- a/updates.json
+++ b/updates.json
@@ -5,7 +5,7 @@
         {
           "version": "4.1.1",
           "update_link": "https://github.com/justinribeiro/zotero-google-scholar-citation-count/releases/download/v4.1.1/zotero-google-scholar-citation-count-4.1.1.xpi",
-          "update_hash": "sha256:a3c87f9bdd999b9f1cc077d033881e5cb1bda9a25ad111b3a898182ae9cdc57a",
+          "update_hash": "sha256:3e9e3e20b490c084b712ead36f37c1daf06b2f7c870f8e350c251d3d4ac5269b",
           "applications": {
             "zotero": {
               "strict_min_version": "6.999",


### PR DESCRIPTION
This feature is to avoid robot check.

When number of fetched items reached 15, delay 30min, then continue fetch.