### PR TITLE
Big update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zotero-google-scholar-citation-count",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "bugs": {
     "url": "https://github.com/justinribeiro/zotero-google-scholar-citation-count/issues"
   },

--- a/src/locale/en-US/gscc-prefs.ftl
+++ b/src/locale/en-US/gscc-prefs.ftl
@@ -1,7 +1,4 @@
-preferences-gscc-enable-random-wait-timing = Set Google Scholar Request Random Wait Intervals
-preferences-gscc-random-wait-timing-explain = To attempt to not trigger the IP shadow ban that Google Scholar implements, GSCC uses a random interval per HTTP request. You can change the window by revising the milliseconds below.
-preferences-gscc-randomWaitMinMs = Minimum Request Wait (milliseconds)
-preferences-gscc-randomWaitMaxMs = Maximum Request Wait (milliseconds)
+preferences-gscc-mirror-title=Mirror URL
 preferences-gscc-search-params = Custom Search Parameters
 preferences-gscc-search-params-explain = Depending on the types of papers you import, sometimes finding matches can be hard. The latest v4.1 of GSCC allows changing the search behavior through flags to help when you need it. In most cases, you shouldn't need the flags below, but if you're having issues, different combinations in different global regions can sometimes help.
 preferences-gscc-useSearchTitleFuzzyMatch= Use Fuzzy Title Match

--- a/src/locale/es-ES/gscc-prefs.ftl
+++ b/src/locale/es-ES/gscc-prefs.ftl
@@ -1,7 +1,4 @@
-preferences-gscc-enable-random-wait-timing = Establecer intervalos de espera aleatorios para las solicitudes de Google Scholar
-preferences-gscc-random-wait-timing-explain = Para intentar no activar la prohibición de IP que implementa Google Scholar, GSCC utiliza un intervalo aleatorio por cada solicitud HTTP. Puede cambiar la ventana modificando los milisegundos a continuación.
-preferences-gscc-randomWaitMinMs = Espera mínima de solicitud (milisegundos)
-preferences-gscc-randomWaitMaxMs = Espera máxima de solicitud (milisegundos)
+preferences-gscc-mirror-title=Espejo URL
 preferences-gscc-search-params = Parámetros de búsqueda personalizados
 preferences-gscc-search-params-explain = Dependiendo de los tipos de documentos que importe, a veces puede ser difícil encontrar coincidencias. La última versión v4.1 de GSCC permite cambiar el comportamiento de búsqueda mediante opciones para ayudarle cuando lo necesite. En la mayoría de los casos, no necesitará las opciones a continuación, pero si tiene problemas, diferentes combinaciones en distintas regiones globales pueden ayudar.
 preferences-gscc-useSearchTitleFuzzyMatch = Usar coincidencia de título difusa

--- a/src/locale/fr-FR/gscc-prefs.ftl
+++ b/src/locale/fr-FR/gscc-prefs.ftl
@@ -1,7 +1,4 @@
-preferences-gscc-enable-random-wait-timing = Définir des intervalles d'attente aléatoires pour les requêtes Google Scholar
-preferences-gscc-random-wait-timing-explain = Pour tenter de ne pas déclencher l'interdiction IP imposée par Google Scholar, GSCC utilise un intervalle aléatoire pour chaque requête HTTP. Vous pouvez modifier la fenêtre en révisant les millisecondes ci-dessous.
-preferences-gscc-randomWaitMinMs = Temps d'attente minimum (millisecondes)
-preferences-gscc-randomWaitMaxMs = Temps d'attente maximum (millisecondes)
+preferences-gscc-mirror-title=Miroir URL
 preferences-gscc-search-params = Paramètres de recherche personnalisés
 preferences-gscc-search-params-explain = En fonction des types de documents que vous importez, il peut parfois être difficile de trouver des correspondances. La dernière version v4.1 de GSCC permet de modifier le comportement de recherche via des options pour vous aider en cas de besoin. Dans la plupart des cas, vous n'aurez pas besoin de ces options, mais si vous rencontrez des problèmes, différentes combinaisons dans différentes régions peuvent parfois aider.
 preferences-gscc-useSearchTitleFuzzyMatch = Utiliser la correspondance floue des titres

--- a/src/locale/ja-JP/gscc-prefs.ftl
+++ b/src/locale/ja-JP/gscc-prefs.ftl
@@ -1,7 +1,4 @@
-preferences-gscc-enable-random-wait-timing = Google Scholar リクエストのランダム待機間隔を設定
-preferences-gscc-random-wait-timing-explain = Google Scholar が実施する IP ブロックを回避するため、GSCC は各 HTTP リクエストにランダムな間隔を使用します。以下のミリ秒単位の設定を変更してウィンドウを調整できます。
-preferences-gscc-randomWaitMinMs = 最小リクエスト待機時間（ミリ秒）
-preferences-gscc-randomWaitMaxMs = 最大リクエスト待機時間（ミリ秒）
+preferences-gscc-mirror-title=ミラーURL
 preferences-gscc-search-params = カスタム検索パラメータ
 preferences-gscc-search-params-explain = インポートする論文の種類によっては、マッチを見つけるのが難しい場合があります。最新の GSCC v4.1 では、必要に応じてフラグを使用して検索動作を変更することができます。ほとんどの場合、以下のフラグは必要ありませんが、問題が発生した場合、異なる地域で異なる組み合わせが役立つことがあります。
 preferences-gscc-useSearchTitleFuzzyMatch = タイトルのファジーマッチを使用

--- a/src/locale/zh-CH/gscc-prefs.ftl
+++ b/src/locale/zh-CH/gscc-prefs.ftl
@@ -1,7 +1,4 @@
-preferences-gscc-enable-random-wait-timing = 设置 Google 学术请求随机等待时间间隔
-preferences-gscc-random-wait-timing-explain = 为了尝试避免触发 Google 学术实施的 IP 阴影禁令，GSCC 对每个 HTTP 请求使用随机间隔。您可以通过修改下面的毫秒数来更改窗口。
-preferences-gscc-randomWaitMinMs = 最小请求等待时间（毫秒）
-preferences-gscc-randomWaitMaxMs = 最大请求等待时间（毫秒）
+preferences-gscc-mirror-title=镜像网址
 preferences-gscc-search-params = 自定义搜索参数
 preferences-gscc-search-params-explain = 根据您导入的论文类型，有时找到匹配项会很困难。最新的 GSCC v4.1 允许通过标志改变搜索行为，以便在需要时提供帮助。在大多数情况下，您不需要使用以下标志，但如果遇到问题，不同全球区域的不同组合有时会有所帮助。
 preferences-gscc-useSearchTitleFuzzyMatch = 使用模糊标题匹配

--- a/src/locale/zh-CH/gscc.ftl
+++ b/src/locale/zh-CH/gscc.ftl
@@ -1,8 +1,8 @@
 gscc-menuitem =
-  .label = 更新 Google 学术引用次数
-gscc-column-name = 引用次数
+  .label = 更新 Google 学术被引次数
+gscc-column-name = 被引次数
 gscc-update-all =
-  .label = 更新所有 Google 学术引用次数。
+  .label = 更新所有 Google 学术被引次数。
 gscc-recapatcha-alert = 请在现在打开的页面上输入验证码，然后重试更新引用，或者如果没有出现验证码，请等待一段时间以解除 Google 的限制。
 gscc-citedByPrefix =  引用自
 gscc-lackPermissions = 您没有权限编辑此库。

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Google Scholar Citation Count",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "Zotero plugin for fetching numbers of citations from Google Scholar.",
   "homepage_url": "https://github.com/justinribeiro/zotero-google-scholar-citation-count",
   "author": "Justin Ribeiro",

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1,6 +1,4 @@
-pref('extensions.zotero.gscc.useRandomWait', true);
-pref('extensions.zotero.gscc.randomWaitMinMs', 1000);
-pref('extensions.zotero.gscc.randomWaitMaxMs', 5000);
+pref('extensions.zotero.gscc.mirrorurl', 'https://scholar.google.com/');
 pref('extensions.zotero.gscc.useSearchTitleFuzzyMatch', false);
-pref('extensions.zotero.gscc.useSearchAuthorsMatch', true);
 pref('extensions.zotero.gscc.useDateRangeMatch', false);
+pref('extensions.zotero.gscc.useSearchAuthorsMatch', true);

--- a/src/prefs.xhtml
+++ b/src/prefs.xhtml
@@ -1,107 +1,36 @@
 <linkset>
   <html:link rel="localization" href="gscc-prefs.ftl" />
 </linkset>
-<vbox>
-  <groupbox aria-labelledby="preferences-gscc-enable-random-wait-timing">
-    <label>
-      <html:h2
-        id="preferences-gscc-enable-random-wait-timing"
-        data-l10n-id="preferences-gscc-enable-random-wait-timing"
-      />
-    </label>
-    <vbox>
-      <html:p
-        id="preferences-gscc-random-wait-timing-explain"
-        data-l10n-id="preferences-gscc-random-wait-timing-explain"
-      />
-    </vbox>
-    <label>
-      <html:h3
-        id="preferences-gscc-randomWaitMinMs"
-        data-l10n-id="preferences-gscc-randomWaitMinMs"
-      />
-    </label>
-    <html:input
-      type="text"
-      preference="extensions.zotero.gscc.randomWaitMinMs"
-    />
-    <label>
-      <html:h3
-        id="preferences-gscc-randomWaitMaxMs"
-        data-l10n-id="preferences-gscc-randomWaitMaxMs"
-      />
-    </label>
-    <html:input
-      type="text"
-      preference="extensions.zotero.gscc.randomWaitMaxMs"
-    />
-  </groupbox>
-  <groupbox aria-labelledby="preferences-gscc-search-params">
-    <vbox>
-      <label>
-        <html:h2
-          id="preferences-gscc-search-params"
-          data-l10n-id="preferences-gscc-search-params"
-        />
-      </label>
-      <html:p
-        id="preferences-gscc-search-params-explain"
-        data-l10n-id="preferences-gscc-search-params-explain"
-      />
-    </vbox>
-    <vbox>
-      <label>
-        <html:h3
-          id="preferences-gscc-useSearchTitleFuzzyMatch"
-          data-l10n-id="preferences-gscc-useSearchTitleFuzzyMatch"
-        />
-      </label>
-      <html:p
-        id="preferences-gscc-useSearchTitleFuzzyMatch-explain"
-        data-l10n-id="preferences-gscc-useSearchTitleFuzzyMatch-explain"
-      />
-    </vbox>
-    <checkbox
-      id="preferences-gscc-useSearchTitleFuzzyMatch-cb"
-      data-l10n-id="preferences-gscc-useSearchTitleFuzzyMatch-cb"
-      preference="extensions.zotero.gscc.useSearchTitleFuzzyMatch"
-      native="true"
-    />
-    <vbox>
-      <label>
-        <html:h3
-          id="preferences-gscc-useDateRangeMatch"
-          data-l10n-id="preferences-gscc-useDateRangeMatch"
-        />
-      </label>
-      <html:p
-        id="preferences-gscc-useDateRangeMatch-explain"
-        data-l10n-id="preferences-gscc-useDateRangeMatch-explain"
-      />
-    </vbox>
-    <checkbox
-      id="preferences-gscc-useDateRangeMatch-cb"
-      data-l10n-id="preferences-gscc-useDateRangeMatch-cb"
-      preference="extensions.zotero.gscc.useDateRangeMatch"
-      native="true"
-    />
-    <vbox>
-      <label>
-        <html:h3
-          id="preferences-gscc-useSearchAuthorsMatch"
-          data-l10n-id="preferences-gscc-useSearchAuthorsMatch"
-        />
-      </label>
-      <html:p
-        id="preferences-gscc-useSearchAuthorsMatch-explain"
-        data-l10n-id="preferences-gscc-useSearchAuthorsMatch-explain"
-      />
-    </vbox>
-    <checkbox
-      id="preferences-gscc-useSearchAuthorsMatch-cb"
-      data-l10n-id="preferences-gscc-useSearchAuthorsMatch-cb"
-      preference="extensions.zotero.gscc.useSearchAuthorsMatch"
-      native="true"
-    />
-  </groupbox>
-</vbox>
+
+<groupbox aria-labelledby="preferences-gscc-mirror-title">
+  <html:b id="preferences-gscc-mirror-title" data-l10n-id="preferences-gscc-mirror-title" style="margin-top: 2em;"/>
+  <hbox style="display: flex; width: 100%;">
+    <menulist preference="extensions.zotero.gscc.mirrorurl" style="flex: 4; min-width: 0; text-align: left;" native="true">
+        <menupopup>
+            <menuitem label="https://scholar.google.com/✅" value="https://scholar.google.com/"/>
+            <menuitem label="https://scholar.lanfanshu.cn/✅" value="https://scholar.lanfanshu.cn/"/>
+            <menuitem label="https://xueshu.lanfanshu.cn/✅" value="https://xueshu.lanfanshu.cn/"/>
+            <menuitem label="https://x.sci-hub.org.cn/❌" value="https://x.sci-hub.org.cn/"/>
+            <menuitem label="https://www.dotaindex.com/❌" value="https://www.dotaindex.com/"/>
+            <menuitem label="https://xs.gupiaoq.com/❌" value="https://xs.gupiaoq.com/"/>
+            <menuitem label="https://xs.vygc.top/❌" value="https://xs.vygc.top/"/>
+            <menuitem label="https://xs.typicalgame.com/❌" value="https://xs.typicalgame.com/"/>
+        </menupopup>
+    </menulist>
+    <html:input type="text" preference="extensions.zotero.gscc.mirrorurl" style="flex: 6; width: 100%; text-align: left;" placeholder="Custom URL"/>
+  </hbox>
+</groupbox>
+
+<groupbox aria-labelledby="preferences-gscc-search-params">
+  <html:b id="preferences-gscc-search-params" data-l10n-id="preferences-gscc-search-params" style="margin-top: 2em;"/>
+  <html:p id="preferences-gscc-search-params-explain" data-l10n-id="preferences-gscc-search-params-explain"/>
+  <html:b id="preferences-gscc-useSearchTitleFuzzyMatch" data-l10n-id="preferences-gscc-useSearchTitleFuzzyMatch" style="margin-top: 2em;"/>
+  <html:p id="preferences-gscc-useSearchTitleFuzzyMatch-explain" data-l10n-id="preferences-gscc-useSearchTitleFuzzyMatch-explain"/>
+  <checkbox id="preferences-gscc-useSearchTitleFuzzyMatch-cb" data-l10n-id="preferences-gscc-useSearchTitleFuzzyMatch-cb" preference="extensions.zotero.gscc.useSearchTitleFuzzyMatch" native="true"/>
+  <html:b id="preferences-gscc-useDateRangeMatch" data-l10n-id="preferences-gscc-useDateRangeMatch" style="margin-top: 2em;"/>
+  <html:p id="preferences-gscc-useDateRangeMatch-explain" data-l10n-id="preferences-gscc-useDateRangeMatch-explain"/>
+  <checkbox id="preferences-gscc-useDateRangeMatch-cb" data-l10n-id="preferences-gscc-useDateRangeMatch-cb" preference="extensions.zotero.gscc.useDateRangeMatch" native="true"/>
+  <html:b id="preferences-gscc-useSearchAuthorsMatch" data-l10n-id="preferences-gscc-useSearchAuthorsMatch" style="margin-top: 2em;"/>
+  <html:p id="preferences-gscc-useSearchAuthorsMatch-explain" data-l10n-id="preferences-gscc-useSearchAuthorsMatch-explain"/>
+  <checkbox id="preferences-gscc-useSearchAuthorsMatch-cb" data-l10n-id="preferences-gscc-useSearchAuthorsMatch-cb" preference="extensions.zotero.gscc.useSearchAuthorsMatch" native="true"/>
+</groupbox>


### PR DESCRIPTION
You can try this version, say goodbye to robot test and wait time.
- [x] Support mirror URL #38 
    - [x] Support change the mirror URL through input box
    - [x] Also can select the plugin’s built-in mirror URL through drop-down menu
    - [x] Delete radom wait time, cause mirror URL will not meet robot test
- [x] Auto run when item added #39 
    - [x] Using `Zotero.Notifier.registerObserver` to monitor added items
- [x] Support delete HTML in title before fetch #35  
    - [x] Using  `item.getField('title').replace(/<[^>]+>/g, '')`
- [x] Show nothing when fetch failed instead of `0`
- [x] Adjust the column width #41 
    - [x] Using `flex:0.4`
- [x] Improve some Chinese localization
- [x] Preference UI redesign
    

<img width="606" alt="Xnip2024-12-07_21-56-49" src="https://github.com/user-attachments/assets/f4ab7735-7254-4201-bb65-543eb572d65d">
